### PR TITLE
Fix unused context

### DIFF
--- a/stress.go
+++ b/stress.go
@@ -13,7 +13,6 @@ func getCommands() []cli.Command {
 	var cpuload float64
 	var duration float64
 	var cpucore int
-	var context *cli.Context
 	sampleInterval := 100 * time.Millisecond
 
 	cpuLoadFlags := []cli.Flag{
@@ -40,7 +39,6 @@ func getCommands() []cli.Command {
 		{
 			Name: "cpu",
 			Action: func(c *cli.Context) {
-				context = c
 				runCpuLoader(sampleInterval, cpuload, duration, cpucore)
 			},
 			Usage:  "load cpu , use --help for more options",


### PR DESCRIPTION
I was trying to compile stress to use it locally, and I found it was not compiling due to unused var.

```
go build stress.go
# command-line-arguments
./stress.go:16:6: context declared and not used
```

In this PR I simply remove that variable to make stress able to compile.